### PR TITLE
Fixes definition of secret into remote_host var

### DIFF
--- a/pyrad/server_async.py
+++ b/pyrad/server_async.py
@@ -58,7 +58,7 @@ class DatagramProtocolServer(asyncio.Protocol):
         if addr[0] in self.hosts:
             remote_host = self.hosts[addr[0]]
         elif '0.0.0.0' in self.hosts:
-            remote_host = self.hosts['0.0.0.0'].secret
+            remote_host = self.hosts['0.0.0.0']
         else:
             self.logger.warn('[%s:%d] Drop package from unknown source %s', self.ip, self.port, addr)
             return


### PR DESCRIPTION
Seemingly due to a typo, the remote_host variable was getting set as the secret when the host is set to 0.0.0.0

2018-12-19 19:01:58,047 [ERROR   ] [127.0.0.1:3799] Error for packet from ('127.0.0.1', 59031)
Traceback (most recent call last):
  File "/home/pons/env/lib/python3.5/site-packages/pyrad/server_async.py", line 90, in datagram_received
    req = CoAPacket(secret=remote_host.secret,
AttributeError: 'bytes' object has no attribute 'secret'